### PR TITLE
Fix temporary file permissions issue for DB

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,5 @@
 [defaults]
 host_key_checking=False
+
+[ssh_connection]
+pipelining=True


### PR DESCRIPTION
Fix for the temporary file permissions issue for DB isntallation

fatal: [peacock]: FAILED! => {"failed": true, "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user. For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}