### PR TITLE
Update Django to latest version 1.11.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.9
+Django==1.11.18
 
 django-braces==1.11.0
 django-celery==3.2.1


### PR DESCRIPTION
@jcalazan this PR helps us update ansible-django-stack to use Python 3.7 as the default Python version :).

See https://github.com/jcalazan/ansible-django-stack/issues/110