### PR TITLE
Update Django to 1.11.26.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.18
+Django==1.11.26
 
 django-braces==1.11.0
 django-celery==3.2.1

--- a/youtubeadl/settings/base.py
+++ b/youtubeadl/settings/base.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = (
     'youtubeadl.apps.downloader',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Change deprecated MIDDLEWARE_CLASSES setting to MIDDLEWARE.

@jcalazan this PR allows the test suite for ansible-django-stack to pass. Currently the deprecated `MIDDLEWARE_CLASSES` setting is breaking the django migrations.