### PR TITLE
Feature/upgrade django middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: xenial
+language: python
+cache: pip
+env:
+  global:
+    - DATABASE_NAME=youtubeadl
+    - DATABASE_USER=youtubeadl
+    - DATABASE_PASSWORD=youtubeadl
+services:
+  - postgresql
+before_script:
+  - psql -c "create user youtubeadl with password 'youtubeadl';" -U postgres
+  - psql -c "alter user youtubeadl CREATEDB;" -U postgres
+  - psql -c 'create database youtubeadl with owner youtubeadl;' -U postgres
+python:
+  - "3.7"
+# command to install dependencies
+install:
+  - pip install -r requirements_local.txt
+# command to run tests
+script: 
+  - python manage.py test

--- a/youtubeadl/apps/core/tests.py
+++ b/youtubeadl/apps/core/tests.py
@@ -1,3 +1,6 @@
 from django.test import TestCase
 
-# Create your tests here.
+
+class SmokeTest(TestCase):
+    def test_application_runs(self):
+        assert True

--- a/youtubeadl/settings/local.py
+++ b/youtubeadl/settings/local.py
@@ -3,7 +3,7 @@ from youtubeadl.settings.base import *
 
 INSTALLED_APPS += ('debug_toolbar',)
 
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', )
+MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware', )
 
 # The Django Debug Toolbar will only be shown to these client IPs.
 INTERNAL_IPS = (


### PR DESCRIPTION
@jcalazan I just realized there was a second place I needed to change `MIDDLEWARE_CLASSES` to `MIDDLEWARE`.

This PR also adds a TravisCI file with a smoke test to make sure the app builds appropriately without errors. I suspect this should be enough for the purposes of using it for the ansible-django-stack repo.